### PR TITLE
Improve import_from_dotted_path error message

### DIFF
--- a/conman/nav_tree/tests/test_utils.py
+++ b/conman/nav_tree/tests/test_utils.py
@@ -41,15 +41,22 @@ class TestSplitPath(TestCase):
 
 
 class TestImportFromDottedPath(TestCase):
+    def assert_error_message(self, exception):
+        """Check the exception's message is correct."""
+        message = 'An import path with two or more components is required.'
+        self.assertEqual(exception.args[0], message)
+
     def test_empty(self):
         """An empty path cannot be imported."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             utils.import_from_dotted_path('')
+        self.assert_error_message(cm.exception)
 
     def test_too_short(self):
         """A path with only one component cannot be imported."""
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as cm:
             utils.import_from_dotted_path('antigravity')
+        self.assert_error_message(cm.exception)
 
     def test_import_module(self):
         """A module can be imported by dotted path."""

--- a/conman/nav_tree/utils.py
+++ b/conman/nav_tree/utils.py
@@ -20,6 +20,11 @@ def import_from_dotted_path(path):
 
     The path must have at least one dot.
     """
-    module_path, attr = path.rsplit('.', 1)
+    try:
+        module_path, attr = path.rsplit('.', 1)
+    except ValueError:
+        message = 'An import path with two or more components is required.'
+        raise ValueError(message) from None
+
     module = importlib.import_module(module_path)
     return getattr(module, attr)


### PR DESCRIPTION
- Avoid exposing `rsplit` implementation detail in exception message.
- Fix #28.
