### PR TITLE
Add Route movement and related methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 * `Route.objects.move_branch()` can be used to move a `Route` and its
   descendants to another location.
+* `Route().move_to(new_url, *, move_children)` can be used to move a `Route`
+  and (optionally) it's descendants to another location.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
   `Route`). One might expect this to be a URL on an external site.
 * Allow `Route` to delegate model checks to the associated handler.
 
+### Added
+
+* `Route.objects.move_branch()` can be used to move a `Route` and its
+  descendants to another location.
+
 ### Changed
 
 * `url` is now editable, rather than generated in `Route.save()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   descendants to another location.
 * `Route().move_to(new_url, *, move_children)` can be used to move a `Route`
   and (optionally) it's descendants to another location.
+* `Route().swap_with(new_url, *, move_children)` can be used to swap a `Route`
+  and (optionally) it's descendants with another `Route`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Backwards incompatible
 
 * Removed `conman.pages` app.
-* Removed `slug` and `parent` fields.
+* Removed `slug` and `parent` fields from Route.
 * Removed dependency upon `django-polymorphic-tree`.
 * Destroyed and recreated migrations.
 * Removed `conman.routes.handlers.SimpleHandler`.

--- a/conman/routes/models.py
+++ b/conman/routes/models.py
@@ -1,6 +1,7 @@
 import uuid
 
 from django.db import IntegrityError, models
+from django.utils.translation import ugettext_lazy as _
 from polymorphic.models import PolymorphicModel
 
 from .handlers import RouteViewHandler
@@ -130,11 +131,11 @@ class Route(PolymorphicModel):
         See https://code.djangoproject.com/ticket/20581.
         """
         if not (self.pk and other_route.pk):
-            raise ValueError('Cannot move unsaved Routes.')
+            raise ValueError(_('Cannot move unsaved Routes.'))
 
         urls = sorted((self.url, other_route.url))
         if move_children and urls[1].startswith(urls[0]):
-            msg = 'Cannot move children when swapping ancestors with descendants.'
+            msg = _('Cannot move children when swapping ancestors with descendants.')
             raise ValueError(msg)
 
         tmp_path = str(uuid.uuid4())

--- a/conman/routes/models.py
+++ b/conman/routes/models.py
@@ -46,8 +46,9 @@ class Route(PolymorphicModel):
 
     def get_ancestors(self):
         """Get all the ancestors of this Route."""
-        paths = split_path(self.url)[:-1]
+        assert self.pk  # Ensure object has been saved.
 
+        paths = split_path(self.url)[:-1]
         return (
             Route.objects
             .exclude(pk=self.pk)
@@ -57,8 +58,8 @@ class Route(PolymorphicModel):
 
     def get_descendants(self):
         """Get all the descendants of this Route."""
-        if not self.pk:
-            return Route.objects.none()
+        assert self.pk  # Ensure object has been saved.
+
         others = Route.objects.exclude(pk=self.pk)
         descendants = others.filter(url__startswith=self.url)
         return descendants.order_by('url')
@@ -130,8 +131,7 @@ class Route(PolymorphicModel):
 
         See https://code.djangoproject.com/ticket/20581.
         """
-        if not (self.pk and other_route.pk):
-            raise ValueError(_('Cannot move unsaved Routes.'))
+        assert self.pk and other_route.pk  # Ensure saved to DB.
 
         urls = sorted((self.url, other_route.url))
         if move_children and urls[1].startswith(urls[0]):

--- a/conman/routes/models.py
+++ b/conman/routes/models.py
@@ -46,7 +46,7 @@ class Route(PolymorphicModel):
 
     def get_ancestors(self):
         """Get all the ancestors of this Route."""
-        assert self.pk  # Ensure object has been saved.
+        assert self.pk is not None  # Ensure object has been saved.
 
         paths = split_path(self.url)[:-1]
         return (
@@ -58,7 +58,7 @@ class Route(PolymorphicModel):
 
     def get_descendants(self):
         """Get all the descendants of this Route."""
-        assert self.pk  # Ensure object has been saved.
+        assert self.pk is not None  # Ensure object has been saved.
 
         others = Route.objects.exclude(pk=self.pk)
         descendants = others.filter(url__startswith=self.url)
@@ -131,7 +131,8 @@ class Route(PolymorphicModel):
 
         See https://code.djangoproject.com/ticket/20581.
         """
-        assert self.pk and other_route.pk  # Ensure saved to DB.
+        # Ensure saved to DB.
+        assert self.pk is not None and other_route.pk is not None
 
         urls = sorted((self.url, other_route.url))
         if move_children and urls[1].startswith(urls[0]):

--- a/conman/routes/models.py
+++ b/conman/routes/models.py
@@ -3,6 +3,7 @@ from polymorphic.models import PolymorphicModel
 
 from .handlers import RouteViewHandler
 from .managers import RouteManager
+from .utils import split_path
 from .validators import (
     validate_end_in_slash,
     validate_no_dotty_subpaths,
@@ -39,6 +40,17 @@ class Route(PolymorphicModel):
     def check(cls):
         """Delegate model checks to the handler."""
         return cls.handler_class.check(cls)
+
+    def get_ancestors(self):
+        """Get all the ancestors of this Route."""
+        paths = split_path(self.url)[:-1]
+
+        return (
+            Route.objects
+            .exclude(pk=self.pk)
+            .filter(url__in=paths)
+            .order_by('url')
+        )
 
     def get_descendants(self):
         """Get all the descendants of this Route."""

--- a/conman/routes/tests/test_models.py
+++ b/conman/routes/tests/test_models.py
@@ -76,7 +76,7 @@ class RouteGetDescendantsTest(TestCase):
             ORDER BY "routes_route"."url" ASC
     """
     def test_just_created(self):
-        """Before object saved, avoid DB hits, and assume no descendants."""
+        """Until saved, return empty Queryset."""
         branch = RouteFactory.build()
 
         with self.assertNumQueries(0):

--- a/conman/routes/tests/test_models.py
+++ b/conman/routes/tests/test_models.py
@@ -76,14 +76,13 @@ class RouteGetAncestorsTest(TestCase):
           ORDER BY "routes_route"."url" ASC
     """
     def test_just_created(self):
-        """Until saved, return empty Queryset."""
+        """Until saved, raise an error."""
         route = RouteFactory.build()
 
+        # Presumed nonsense as unsaved, so no query.
         with self.assertNumQueries(0):
-            # Presumed nonsense as unsaved, so no query.
-            ancestors = list(route.get_ancestors())
-
-        self.assertEqual(ancestors, [])
+            with self.assertRaises(AssertionError):
+                route.get_ancestors()
 
     def test_no_ancestors(self):
         """Without ancestors, we get an empty result."""
@@ -144,11 +143,10 @@ class RouteGetDescendantsTest(TestCase):
         """Until saved, return empty Queryset."""
         branch = RouteFactory.build()
 
+        # Descendants presumed nonsense as unsaved, so no query.
         with self.assertNumQueries(0):
-            # Descendants presumed nonsense as unsaved, so no query.
-            descendants = list(branch.get_descendants())
-
-        self.assertEqual(descendants, [])
+            with self.assertRaises(AssertionError):
+                branch.get_descendants()
 
     def test_no_descendants(self):
         """When an Route has no descendants, return no objects."""
@@ -448,11 +446,10 @@ class TestRouteSwapWith(TestCase):
         route_1 = RouteFactory.create(url='/a/')
         route_2 = RouteFactory.build(url='/b/')
 
-        msg = 'Cannot move unsaved Routes.'
         with self.assertNumQueries(0):
-            with self.assertRaisesMessage(ValueError, msg):
+            with self.assertRaises(AssertionError):
                 route_1.swap_with(route_2, move_children=True)
-            with self.assertRaisesMessage(ValueError, msg):
+            with self.assertRaises(AssertionError):
                 route_2.swap_with(route_1, move_children=True)
 
 

--- a/conman/routes/tests/test_utils.py
+++ b/conman/routes/tests/test_utils.py
@@ -16,7 +16,7 @@ class TestSplitPath(TestCase):
             '/a/path/with/many/',
             '/a/path/with/many/parts/',
         ]
-        self.assertCountEqual(paths, expected)  # Order does not matter
+        self.assertEqual(paths, expected)
 
     def test_split_empty_path(self):
         """An empty path has sub-path '/'."""

--- a/conman/routes/utils.py
+++ b/conman/routes/utils.py
@@ -12,7 +12,7 @@ def split_path(path):
     path = path.rstrip('/')
 
     while path:
-        paths.append(path + '/')
+        paths.insert(1, path + '/')
         path = os.path.split(path)[0]
         if path == '/':
             break

--- a/conman/routes/utils.py
+++ b/conman/routes/utils.py
@@ -1,4 +1,4 @@
-import os
+from collections import deque
 
 
 def split_path(path):
@@ -7,13 +7,17 @@ def split_path(path):
 
     A url's sub-paths consist of all substrings ending in / and starting at
     the start of the url.
-    """
-    paths = ['/']
-    path = path.rstrip('/')
 
+    eg: /path/containing/subpaths/ becomes:
+
+        /
+        /path/
+        /path/containing/
+        /path/containing/subpaths/
+    """
+    paths = deque()
+    path = path or '/'
     while path:
-        paths.insert(1, path + '/')
-        path = os.path.split(path)[0]
-        if path == '/':
-            break
-    return paths
+        path = path.rpartition('/')[0]
+        paths.appendleft(path + '/')
+    return list(paths)


### PR DESCRIPTION
Deferred from #75:
- [x] Rebase once #75 is merged.
- [x] Add `Route.objects.move_branch(old_url, new_url)`.
- [x] Add `Route().get_ancestors()`
- [x] Add `Route().swap_with(other_route, move_children)`
- [x] Add `Route().move_to(new_url, move_children)`
- [x] Decide if these method ought to be in atomic transactions or not. *Conclusion: not at the moment.*
- [x] Determine if validation is worthwhile on the above methods. *Conclusion: yes, but optionally disabled with flag. Defer to another PR.*
- [x] Raise error from `get_ancestors` when called on object that hasn't yet been saved to the database (has no `pk`).
- [x] Mark user-facing strings as translatable.
- [x] Consider re-writing long queries to clarify their single-query nature (remove line-smearing variables).

Trashed ideas:

~~- [ ] Add `Route.objects.swap_urls(first, second)` method.~~
~~- [ ] Add `Route.objects.swap_branches(first, second)` method.~~
~~- [ ] Add `Route().get_parent()`~~