### PR TITLE
Add missing migration

### DIFF
--- a/conman/routes/migrations/0003_add_validators.py
+++ b/conman/routes/migrations/0003_add_validators.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import conman.routes.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('routes', '0002_remove_slug_parent'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='route',
+            name='url',
+            field=models.TextField(db_index=True, validators=[conman.routes.validators.validate_end_in_slash, conman.routes.validators.validate_start_in_slash, conman.routes.validators.validate_no_dotty_subpaths, conman.routes.validators.validate_no_double_slashes, conman.routes.validators.validate_no_hash_symbol, conman.routes.validators.validate_no_questionmark], unique=True),
+        ),
+    ]


### PR DESCRIPTION
This should have been added when the validators were added to `Route.url`.