### PR TITLE
Consistently format SQL in (test) examples

### DIFF
--- a/conman/routes/tests/test_managers.py
+++ b/conman/routes/tests/test_managers.py
@@ -10,19 +10,20 @@ class RouteManagerBestMatchForPathTest(TestCase):
 
     All of these tests assert use of only one query:
         * Get the best Route based on url:
-            SELECT
-                (LENGTH(url)) AS "length",
-                <other fields>
-            FROM "routes_route"
-            WHERE
-                "routes_route"."url" IN (
-                    '/',
-                    '/url/',
-                    '/url/split/',
-                    '/url/split/into/',
-                    '/url/split/into/bits/')
+
+              SELECT "routes_route"."id",
+                     "routes_route"."polymorphic_ctype_id",
+                     "routes_route"."url",
+                     LENGTH("routes_route"."url") AS "length"
+                FROM "routes_route"
+               WHERE "routes_route"."url"
+                  IN ('/',
+                      '/url/',
+                      '/url/split/',
+                      '/url/split/into/',
+                      '/url/split/into/bits/')
             ORDER BY "length" DESC
-            LIMIT 1
+               LIMIT 1
     """
     def test_get_root(self):
         """Check a Root Route matches a simple '/' path."""
@@ -68,19 +69,19 @@ class RouteManagerBestMatchForBrokenPathTest(TestCase):
 
     All of these tests assert use of only one query:
         * Get the best Route based on url:
-            SELECT
-                (LENGTH(url)) AS "length",
-                <other fields>
-            FROM "routes_route"
-            WHERE
-                "routes_route"."url" IN (
-                    '/',
-                    '/url/',
-                    '/url/split/',
-                    '/url/split/into/',
-                    '/url/split/into/bits/')
+              SELECT "routes_route"."id",
+                     "routes_route"."polymorphic_ctype_id",
+                     "routes_route"."url",
+                     LENGTH("routes_route"."url") AS "length"
+                FROM "routes_route"
+               WHERE "routes_route"."url"
+                  IN ('/',
+                      '/url/',
+                      '/url/split/',
+                      '/url/split/into/',
+                      '/url/split/into/bits/')
             ORDER BY "length" DESC
-            LIMIT 1
+               LIMIT 1
     """
     def test_throw_error_without_match(self):
         """Check Route.DoesNotExist is raised if no Root Route exists."""

--- a/conman/routes/tests/test_models.py
+++ b/conman/routes/tests/test_models.py
@@ -50,12 +50,13 @@ class RouteGetDescendantsTest(TestCase):
     All of these tests assert use of only one query:
         * Get the decendants of a Route:
 
-            SELECT * FROM "routes_route"
-            WHERE (
-                NOT ("routes_route"."id" = <id>)
-                AND "routes_route"."url"::text LIKE '<url>%'
-            )
-            ORDER BY "routes_route.url" DESC
+              SELECT "routes_route"."id",
+                     "routes_route"."polymorphic_ctype_id",
+                     "routes_route"."url"
+                FROM "routes_route"
+               WHERE (NOT ("routes_route"."id" = 25)
+                      AND "routes_route"."url"::text LIKE '/slug25/%')
+            ORDER BY "routes_route"."url" ASC
     """
     def test_just_created(self):
         branch = RouteFactory.build()


### PR DESCRIPTION
I'm quite taken by http://sqlstyle.guide/, and at the time of writing there was no clear pattern to the formatting. Should be pretty easy to update them.