### PR TITLE
RouteViewHandler check raised on Route

### DIFF
--- a/conman/routes/models.py
+++ b/conman/routes/models.py
@@ -42,6 +42,9 @@ class Route(PolymorphicModel):
     @classmethod
     def check(cls):
         """Delegate model checks to the handler."""
+        # Skip checks on the base class. They're intended for subclasses.
+        if cls == Route:
+            return []
         return cls.handler_class.check(cls)
 
     def get_ancestors(self):


### PR DESCRIPTION
The check ensures that `Route` models handled by `RouteViewHandler` have a `view` attribute.

Unfortunately, it's failing on `Route` itself, instead of on just the subclasses which will actually have instances.

As we should never really have a `Route` instance in the DB, it shouldn't need a `view` attribute.