### PR TITLE
Add flake8-commas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dj-database-url==0.4.1
 django~=1.11.0
 factory_boy==2.8.1
 flake8==2.2.5
+flake8-commas==0.4.3
 flake8-docstrings==0.2.8
 incuna-test-utils==6.6.0
 isort==4.2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ skip_covered = True
 max-line-length = 90
 max-complexity = 10
 exclude = *migrations*
-ignore = D100,D104,D203,D204
+ignore = D100,D104,D203,D204,C814,C815,C816
 statistics=true
 
 [isort]


### PR DESCRIPTION
This will ensure that we add trailing commas where required.

~~The [`flake8-commas`](https://github.com/flake8-commas/flake8-commas) project still seems to be ironing out a few kinks at the moment, so perhaps it's worth waiting for it to settle for a while first, lest it become a blocker.~~ Not seem movement on it for a while -- presuming stability.