### PR TITLE
Remove unnecessary test decorator

### DIFF
--- a/tests/routes/test_handlers.py
+++ b/tests/routes/test_handlers.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.core.checks import Error
 from django.core.urlresolvers import clear_url_caches, Resolver404
 from django.test import TestCase
-from django.test.utils import isolate_apps
 
 from conman.routes.handlers import BaseHandler, RouteViewHandler, URLConfHandler
 from tests.models import RouteSubclass, URLConfRoute
@@ -61,7 +60,6 @@ class SubclassHandleTest(TestCase):
         self.assertEqual(TestHandler(None).handle(None, None), expected)
 
 
-@isolate_apps()
 class URLConfHandlerHandleTest(TestCase):
     """Test URLConfHandler.handle()."""
     def setUp(self):
@@ -103,7 +101,6 @@ class URLConfHandlerHandleTest(TestCase):
         self.assertFalse(dummy_view.called)
 
 
-@isolate_apps()
 class URLConfHandlerCheckTest(TestCase):
     """Tests for URLConfHandler.check()."""
     def test_no_urlconf(self):
@@ -131,7 +128,6 @@ class URLConfHandlerCheckTest(TestCase):
         self.assertEqual(errors, [])
 
 
-@isolate_apps()
 class RouteViewHandlerCheckTest(TestCase):
     """Tests for RouteViewHandler.check()."""
     def test_no_view(self):

--- a/tests/routes/test_models.py
+++ b/tests/routes/test_models.py
@@ -2,7 +2,6 @@ from unittest import mock
 
 from django.db import IntegrityError, transaction
 from django.test import TestCase
-from django.test.utils import isolate_apps
 from incuna_test_utils.utils import field_names
 
 from conman.routes import handlers
@@ -51,7 +50,6 @@ class RouteUniquenessTest(TestCase):
             Route.objects.create(url='/')
 
 
-@isolate_apps()
 class RouteCheckTest(TestCase):
     """Test Route.check()."""
     def test_route_subclass(self):


### PR DESCRIPTION
_What was the problem:_

We no longer needed `@isolate_apps` in the tests.

It hasn't been required since 47802365945b2e772b728e399ec65c9ccad5f15d.

_How this solves the problem:_

It has been deleted.

_Please ensure you have (if appropriate):_

- [x] Run the test suite / style guide checkers.
- ~~Added tests.~~
- ~~Updated the docs.~~
- ~~Updated the changelog.~~