### PR TITLE
Reduce severity of some django checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@
 - `CONMAN_ADMIN_ROUTES` setting has been removed. In future, we'll
   automatically detect subclasses of `Route` for admin integration.
 
+### Changed
+
+- Reduced severity of `subclasses_available` and `subclasses_in_admin` checks,
+  as well as checks for `urlconf` and `view` on handlers that need it. They
+  were previously `Error`, and are now `Warning`. `E002` and `E003` are changed
+  to `W001` and `W002`.
+
 
 ## 0.1.1 2017-09-29
 

--- a/conman/routes/checks.py
+++ b/conman/routes/checks.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 from django.contrib import admin
-from django.core.checks import Error
+from django.core.checks import Error, Warning
 
 
 def polymorphic_installed(app_configs, **kwargs):
@@ -21,18 +21,15 @@ def polymorphic_installed(app_configs, **kwargs):
 
 def subclasses_available(app_configs, **kwargs):
     """Check that at least one Route subclass is available."""
-    errors = []
     routes = apps.get_app_config('routes')
     Route = routes.get_model('Route')
     if not Route.__subclasses__():
-        error = Error(
+        return [Warning(
             'No Route subclasses are available.',
             hint='Add another conman module to INSTALLED_APPS.',
-            id='conman.routes.E002',
-        )
-        errors.append(error)
-
-    return errors
+            id='conman.routes.W001',
+        )]
+    return []
 
 
 def subclasses_in_admin(app_configs, **kwargs):
@@ -44,9 +41,9 @@ def subclasses_in_admin(app_configs, **kwargs):
     route_subclasses = set(Route.get_subclasses())
     missing = route_subclasses.difference(admin.site._registry)
     if missing:
-        return [Error(
+        return [Warning(
             'Route subclasses missing from admin.',
             hint='Missing: {}.'.format(missing),
-            id='conman.routes.E003',
+            id='conman.routes.W002',
         )]
     return []

--- a/conman/routes/handlers.py
+++ b/conman/routes/handlers.py
@@ -42,7 +42,7 @@ class URLConfHandler(BaseHandler):
     def check(cls, route):
         """Ensure route has a sensible urlconf attribute."""
         if not hasattr(route, 'urlconf'):
-            return [checks.Error(
+            return [checks.Warning(
                 '{} must have a `urlconf` attribute.'.format(route.__name__),
                 hint=(
                     'The urlconf must be a dotted path. ' +
@@ -78,7 +78,7 @@ class RouteViewHandler(BaseHandler):
     def check(cls, route):
         """Ensure route has a sensible view attribute."""
         if not hasattr(route, 'view'):
-            return [checks.Error(
+            return [checks.Warning(
                 '{} must have a `view` attribute.'.format(route.__name__),
                 hint='This is a requirement of {}.'.format(cls.__name__),
                 obj=route,

--- a/tests/routes/test_checks.py
+++ b/tests/routes/test_checks.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.contrib import admin
-from django.core.checks import Error
+from django.core.checks import Error, Warning
 from django.core.checks.registry import registry
 from django.test import SimpleTestCase
 
@@ -53,14 +53,14 @@ class SubclassesAvailableTest(SimpleTestCase):
         """The check fails if no subclass of Route is available."""
         with mock.patch('conman.routes.models.Route.__subclasses__') as subclasses:
             subclasses.return_value = []
-            errors = checks.subclasses_available(app_configs=None)
+            result = checks.subclasses_available(app_configs=None)
 
-        error = Error(
+        expected = Warning(
             'No Route subclasses are available.',
             hint='Add another conman module to INSTALLED_APPS.',
-            id='conman.routes.E002',
+            id='conman.routes.W001',
         )
-        self.assertEqual(errors, [error])
+        self.assertEqual(result, [expected])
 
 
 class SubclassesInAdminTest(SimpleTestCase):
@@ -86,10 +86,10 @@ class SubclassesInAdminTest(SimpleTestCase):
             # Restore the admin to pre-test status.
             admin.site.register(NestedRouteSubclass, admin_class)
 
-        expected = Error(
+        expected = Warning(
             'Route subclasses missing from admin.',
             hint="Missing: {<class 'tests.models.NestedRouteSubclass'>}.",
-            id='conman.routes.E003',
+            id='conman.routes.W002',
         )
         self.assertEqual(result, [expected])
 
@@ -104,9 +104,9 @@ class SubclassesInAdminTest(SimpleTestCase):
         admin.site.unregister(NestedRouteSubclass)
         try:
             with mock.patch(path, return_value=False, autospec=True):
-                errors = checks.subclasses_in_admin(app_configs=None)
+                result = checks.subclasses_in_admin(app_configs=None)
         finally:
             # Restore the admin to pre-test status.
             admin.site.register(NestedRouteSubclass, admin_class)
 
-        self.assertEqual(errors, [])
+        self.assertEqual(result, [])

--- a/tests/routes/test_handlers.py
+++ b/tests/routes/test_handlers.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from django.core.checks import Error
+from django.core.checks import Warning
 from django.core.urlresolvers import clear_url_caches, Resolver404
 from django.test import TestCase
 from django.test.utils import isolate_apps
@@ -115,7 +115,7 @@ class URLConfHandlerCheckTest(TestCase):
         finally:
             URLConfRoute.urlconf = removed_urlconf
 
-        expected = Error(
+        expected = Warning(
             'URLConfRoute must have a `urlconf` attribute.',
             hint=(
                 'The urlconf must be a dotted path. ' +
@@ -143,7 +143,7 @@ class RouteViewHandlerCheckTest(TestCase):
         finally:
             RouteSubclass.view = removed_view
 
-        expected = Error(
+        expected = Warning(
             'RouteSubclass must have a `view` attribute.',
             hint='This is a requirement of RouteViewHandler.',
             obj=RouteSubclass,


### PR DESCRIPTION
_What was the problem:_

Checks are great, but the Error level ones really get in the way of development.

Exceptionally, I've left in the error for when you've forgotten to add `'polymorphic',` to the `INSTALLED_APPS`.

_How this solves the problem:_

This reduces some of the checks from `Error` to `Warning`.

- [x] Run the test suite / style guide checkers.
- ~Added tests.~
- ~Updated the docs.~
- [x] Updated the changelog.