### PR TITLE
Support Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,15 @@ env:
   global:
     - DATABASE_URL='postgres://postgres@localhost/conman'
   matrix:
-    - DJANGO='django~=1.10.0'
     - DJANGO='django~=1.11.0'
+    - DJANGO='django~=2.0.1'
     - DJANGO='https://github.com/django/django/tarball/master'
 
 matrix:
   allow_failures:
     - env: DJANGO='https://github.com/django/django/tarball/master'
+    - env: DJANGO='django~=2.0.1'
+      python: 3.4
   fast_finish: true
 
 install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@
 
 ### Added
 
+- Added support for Django 2.0.
 - Added `Route.get_subclasses()`.
 - Added `TemplateHandler`. A simpler handler that requires only a template.
   This is the new default for `Route.handler_class`.
 
 ### Backwards incompatible
 
+- Dropped support for Django 1.10.
 - `CONMAN_ADMIN_ROUTES` setting has been removed. In future, we'll
   automatically detect subclasses of `Route` for admin integration.
 - Renamed `RouteViewHandler` to `ViewHandler`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 colour-runner==0.0.5
 coverage==4.4.2
 dj-database-url==0.4.1
-django~=1.11.0
+django~=2.0.1
 factory_boy==2.9.2
 flake8==3.5.0
 flake8-commas==1.0.0

--- a/tests/routes/test_admin.py
+++ b/tests/routes/test_admin.py
@@ -1,6 +1,8 @@
+from unittest import mock
+
 from django.contrib.admin import site
 from django.contrib.admin.widgets import AdminTextInputWidget
-from django.test import mock, SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase
 
 from conman.routes.admin import RouteParentAdmin
 from conman.routes.models import Route

--- a/tests/routes/test_handlers.py
+++ b/tests/routes/test_handlers.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 from django.core.checks import Warning
-from django.core.urlresolvers import clear_url_caches, Resolver404
 from django.http import HttpResponse
 from django.test import RequestFactory, TestCase
+from django.urls import clear_url_caches, Resolver404
 
 from conman.routes.handlers import (
     BaseHandler,

--- a/tests/routes/test_urls.py
+++ b/tests/routes/test_urls.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import resolve, Resolver404
 from django.test import TestCase
+from django.urls import resolve, Resolver404
 
 from conman.routes import views
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-from incuna_test_utils.testcases.integration import BaseIntegrationTestCase
 from incuna_test_utils.testcases.request import BaseRequestTestCase
 
 from .factories import UserFactory
@@ -6,9 +5,4 @@ from .factories import UserFactory
 
 class RequestTestCase(BaseRequestTestCase):
     """Add helper methods for working with requests in tests."""
-    user_factory = UserFactory
-
-
-class IntegrationTestCase(BaseIntegrationTestCase):
-    """Add helper methods for integration tests."""
     user_factory = UserFactory


### PR DESCRIPTION
Django 2.0's release notes recommend dropping support for Django below version 1.11, so let's do that.

This will be blocked by django-polymorphic, I expect.

Django 2.0 is scheduled to drop in December of 2017.